### PR TITLE
Refactor how station retrieval is connected between transfers and equivalence

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,16 @@
 
 - [NYC Subway Journey Game React App](#nyc-subway-journey-game-react-app)
     - [Screenshots](#screenshots)
+- [Running the project](#running-the-project)
   - [Play online](#play-online)
   - [Running the project locally with Docker](#running-the-project-locally-with-docker)
-    - [1. Clone the repository:](#1-clone-the-repository)
-    - [2. Build the Docker image:](#2-build-the-docker-image)
-    - [3. Run the Docker container:](#3-run-the-docker-container)
-    - [4. Open the application:](#4-open-the-application)
+      - [1. Clone the repository](#1-clone-the-repository)
+      - [2. Build the Docker image](#2-build-the-docker-image)
+      - [3. Run the Docker container](#3-run-the-docker-container)
+      - [4. Open the application](#4-open-the-application)
+  - [Running the project locally with Node.js](#running-the-project-locally-with-nodejs)
+      - [1. Clone the repository](#1-clone-the-repository-1)
+      - [2. Install dependencies and run project](#2-install-dependencies-and-run-project)
   - [How to play](#how-to-play)
     - [Initialization](#initialization)
     - [Gameplay](#gameplay)
@@ -20,64 +24,90 @@
 ### Screenshots
 | ![cover screenshot 1](./src/images/cover-screenshot-1.png) | ![cover screenshot 2](./src/images/cover-screenshot-2.png) |
 | -----------------------------------------------------------| ---------------------------------------------------------- |
+<br>
 
 
-## Play <a href="https://nolansmug.github.io/" target="_blank">online</a>
+# Running the project
 
+
+## Play [online](https://nolansmug.github.io/)
 - Currently hosted on GitHub Pages
-
 
 ## Running the project locally with Docker
 
 > Make sure you have Docker [installed](https://www.docker.com/get-started)
-### 1. Clone the repository:
+#### 1. Clone the repository
   ```bash
   git clone https://github.com/NolanSmug/nyc-subway-journey-react
   cd nyc-subway-journey-react
   ```
 
-### 2. Build the Docker image:
+#### 2. Build the Docker image
   ```bash
   docker build -t subway-game .
   ```
 
-### 3. Run the Docker container:
+#### 3. Run the Docker container
   ```bash
   docker run -p 3000:3000 subway-game
   ```
 
-### 4. Open the application:
+#### 4. Open the application
   Open your browser and go to [http://localhost:3000](http://localhost:3000).
 
 > If the app doesn't load, make sure Docker is [installed](https://www.docker.com/get-started) and running.
+
+## Running the project locally with Node.js
+> Make sure you have `Node.js` [installed](https://nodejs.org/en/download) 
+
+#### 1. Clone the repository
+  ```bash
+  git clone https://github.com/NolanSmug/nyc-subway-journey-react
+  cd nyc-subway-journey-react
+  ```
+
+#### 2. Install dependencies and run project
+**Npm**
+> Make sure you have `npm` [installed](https://www.npmjs.com/get-npm)  
+  ```bash
+  npm install
+  npm run start
+  ```
+
+**Yarn**
+> Make sure you have `yarn` [installed](https://yarnpkg.com/getting-started/install)
+  ```bash
+  yarn install
+  yarn start
+  ```
 
 ## How to play
 You are placed into a random NYC subway station. Your objective is to reach another randomly given station by utilizing your knowledge of the NYC subway system.
 
 ### Initialization
-1. **Random Starting Point:**
+1. **Random starting point:**
 - At the beginning of the game, you are assigned:
   - A `starting station` 
   - A `destination station` (see [all_stations.csv](./public/csv/all_stations.csv))
   - A `starting line` (e.g., A, 2, N,...)
-2. **Choosing a Direction:**
+2. **Choosing a direction:**
 - Before you can move, you must choose a `starting direction` (e.g. UPTOWN, DOWNTOWN) by either: 
-   - Clicking the `[Toggle Direction]` text on the subway car, or 
-   - Clicking `Change Direction` button. 
+   - Clicking the `[Toggle direction]` text on the subway car, or 
+   - Clicking `Change direction` button. 
 - The `Advance` button will remain disabled until a direction is chosen.
      > If you want, you may transfer to a different line before selecting a direction.
-3. **Ready to Move:**
+3. **Ready to move:**
 - Once a direction is selected, you are able to `Advance` and `Transfer`. 
 
 ### Gameplay
 
-1. **Navigating the Subway:**
+1. **Navigating the subway:**
 - The game UI displays your `current station` and `destination station`. Like you would in real life, use the according actions to progress:
 
    **Buttons:**
-  -  `Advance Station` – Advance 1 station (see `conductor mode` to control this value)
-  -  `Change Direction` – Reverses your current direction. Each line has specific `UPTOWN` and `DOWNTOWN` labels.
-  -  `Transfer Lines` –  Click on a subway line at your `current station` to switch to that line and continue your journey in the same direction.
+  -  `Advance station` – Advance 1 station (see `conductor mode` to control this value)
+  -  `Change direction` – Reverses your current direction. Each line has specific `UPTOWN` and `DOWNTOWN` labels.
+  -  `Transfer lines` –  Click on a subway line at your `current station` to switch to that line and continue your journey in the same direction.
       > **Note:** Using this button is optional. You can directly click on a subway line icon at the current station to switch to it as well.
   - `Refresh` – Refreshes the current game with new starting and destination stations.  
 <br>
@@ -87,9 +117,9 @@ You are placed into a random NYC subway station. Your objective is to reach anot
   
 ### Configuration settings
 - **`Theme`** – Toggle light/dark mode
-- **`Upcoming Stations`** – Toggle upcoming stations visibility
-- **`Upcoming Stations Layout`** – Set the upcoming stations view to vertical or horizontal
-- **`Conductor Mode`** – Enable conductor mode (default is rider mode)
+- **`Upcoming stations`** – Toggle upcoming stations visibility
+- **`Upcoming stations layout`** – Toggle the upcoming stations view between vertical or horizontal
+- **`Conductor mode`** – Enable conductor mode (default is rider mode)
 
 
 ### Conductor mode
@@ -98,27 +128,27 @@ Think of conductor mode as a sort of a professional feature mode. When enabled, 
 1. Advance an input number of stations (with "reset to 1" button)
 2. Configure the "default" `starting direction` upon completing a transfer
    - `Uptown`
-   - `Select Direction` (user is given choice of direction each time)
+   - `Select direction` (user is given choice of direction each time)
    - `Downtown`
 3. View all available [keyboard shortcuts](#keyboard-shortcuts)
 
 | ![conductor mode](./src/images/conductor-mode-screenshot.png) |
 | ------------------------------------------------------------- | 
 
-> The 'Uptown' text fades shortly after each toggle click.
+> The "Uptown" text fades shortly after each toggle click.
 
 ### Keyboard shortcuts
-- `→` Advance Station
-- `t` Transfer Lines
-- `c` Change Direction
-- `r` Reset Game
-- `+` Increase Advance Count
-- `-` Decrease Advance Count
+- `→` Advance station
+- `t` Transfer lines
+- `c` Change direction
+- `r` Reset game
+- `+` Increase advance count
+- `-` Decrease advance count
 <br><br>
 - `Shift` + `D` – Toggle **Theme**
-- `Shift` + `U` – Toggle **Upcoming Stations**
-- `Shift` + `L` – Toggle **Upcoming Stations Layout**
-- `Shift` + `C` – Toggle **Conductor Mode**
+- `Shift` + `U` – Toggle **Upcoming stations**
+- `Shift` + `L` – Toggle **Upcoming stations layout**
+- `Shift` + `C` – Toggle **Conductor mode**
 
 <br><br>
 

--- a/public/csv/a_train_lefferts_stations.csv
+++ b/public/csv/a_train_lefferts_stations.csv
@@ -11,16 +11,16 @@ A51,Broadway Junction,A C,Bk
 A48,Utica Av,A C,Bk
 A46,Nostrand Av,A C,Bk
 A42,Hoyt-Schermerhorn Sts,A C G,Bk
-A41,Jay St-MetroTech,A C F R,Bk
+JAY,Jay St-MetroTech,A C F R,Bk
 A40,High St,A C,Bk
-A38,Fulton St,2 3 4 5 A C J Z,M
+FUL,Fulton St,2 3 4 5 A C J Z,M
 A36,Chambers St,A C,M
 A34,Canal St,A C E,M
 A32,W 4 St-Wash Sq,A C E B D F M,M
-A31,14 St (8th Av),A C E L,M
-A28,34 St-Penn Station,A C E 1 2 3,M
+L01,14 St (8th Av),A C E L,M
+PEN,34 St-Penn Station,A C E 1 2 3,M
 A27,42 St-Port Authority Bus Terminal,A C E,M
-A24,59 St-Columbus Circle,A B C D 1,M
+CLC,59 St-Columbus Circle,A B C D 1,M
 A15,125 St,A C B D,M
 A12,145 St,A C B D,M
 A09,168 St,A C 1,M

--- a/public/csv/a_train_rockaway-mott_stations.csv
+++ b/public/csv/a_train_rockaway-mott_stations.csv
@@ -15,16 +15,16 @@ A51,Broadway Junction,A C,Bk
 A48,Utica Av,A C,Bk
 A46,Nostrand Av,A C,Bk
 A42,Hoyt-Schermerhorn Sts,A C G,Bk
-A41,Jay St-MetroTech,A C F R,Bk
+JAY,Jay St-MetroTech,A C F R,Bk
 A40,High St,A C,Bk
-A38,Fulton St,2 3 4 5 A C J Z,M
+FUL,Fulton St,2 3 4 5 A C J Z,M
 A36,Chambers St,A C,M
 A34,Canal St,A C E,M
 A32,W 4 St-Wash Sq,A C E B D F M,M
-A31,14 St (8th Av),A C E L,M
-A28,34 St-Penn Station,A C E 1 2 3,M
+L01,14 St (8th Av),A C E L,M
+PEN,34 St-Penn Station,A C E 1 2 3,M
 A27,42 St-Port Authority Bus Terminal,A C E,M
-A24,59 St-Columbus Circle,A B C D 1,M
+CLC,59 St-Columbus Circle,A B C D 1,M
 A15,125 St,A C B D,M
 A12,145 St,A C B D,M
 A09,168 St,A C 1,M

--- a/public/csv/a_train_stations.csv
+++ b/public/csv/a_train_stations.csv
@@ -8,16 +8,16 @@ A51,Broadway Junction,A C,Bk
 A48,Utica Av,A C,Bk
 A46,Nostrand Av,A C,Bk
 A42,Hoyt-Schermerhorn Sts,A C G,Bk
-A41,Jay St-MetroTech,A C F R,Bk
+JAY,Jay St-MetroTech,A C F R,Bk
 A40,High St,A C,Bk
-A38,Fulton St,2 3 4 5 A C J Z,M
+FUL,Fulton St,2 3 4 5 A C J Z,M
 A36,Chambers St,A C,M
 A34,Canal St,A C E,M
 A32,W 4 St-Wash Sq,A C E B D F M,M
-A31,14 St (8th Av),A C E L,M
-A28,34 St-Penn Station,A C E 1 2 3,M
+L01,14 St (8th Av),A C E L,M
+PEN,34 St-Penn Station,A C E 1 2 3,M
 A27,42 St-Port Authority Bus Terminal,A C E,M
-A24,59 St-Columbus Circle,A B C D 1,M
+CLC,59 St-Columbus Circle,A B C D 1,M
 A15,125 St,A C B D,M
 A12,145 St,A C B D,M
 A09,168 St,A C 1,M

--- a/public/csv/all_stations.csv
+++ b/public/csv/all_stations.csv
@@ -23,30 +23,21 @@ A14,135 St,B C,M
 224,135 St,2 3,M
 115,137 St-City College,1,M
 416,138 St-Grand Concourse,4 5,Bx
-D19,14 St (6th Av),1 2 3 F M L,M
-L02,14 St (6th Av),1 2 3 F M L,M
 132,14 St (6th Av),1 2 3 F M L,M
-A31,14 St (8th Av),A C E L,M
 L01,14 St (8th Av),A C E L,M
-635,14 St-Union Sq,4 5 6 N Q R W L,M
-L03,14 St-Union Sq,4 5 6 N Q R W L,M
-R20,14 St-Union Sq,4 5 6 N Q R W L,M
+USQ,14 St-Union Sq,4 5 6 N Q R W L,M
 A12,145 St,A C B D,M
-D13,145 St,A C B D,M
 114,145 St,1,M
-222,149 St-Grand Concourse,2 5,Bx
-415,149 St-Grand Concourse,4,Bx
+222,149 St-Grand Concourse,2 4 5,Bx
 F25,15 St-Prospect Park,F G,Bk
 D12,155 St,B D,M
 A11,155 St,C,M
 113,157 St,1,M
-D11,161 St-Yankee Stadium,B D,Bx
-414,161 St-Yankee Stadium,4,Bx
+NYY,161 St-Yankee Stadium,B D 4,Bx
 A10,163 St-Amsterdam Av,C,M
 D10,167 St,B D,Bx
 413,167 St,4,Bx
 A09,168 St,A C 1,M
-112,168 St,A C 1,M
 F02,169 St,F,Q
 D09,170 St,B D,Bx
 412,170 St,4,Bx
@@ -92,20 +83,16 @@ L05,3 Av,L,M
 R04,30 Av,N W,Q
 632,33 St,6,M
 716,33 St-Rawson St,7,Q
-D17,34 St-Herald Sq,B D F M N Q R W,M
-R17,34 St-Herald Sq,B D F M N Q R W,M
+HSQ,34 St-Herald Sq,B D F M N Q R W,M
 726,34 St-Hudson Yards,7,M
-A28,34 St-Penn Station,A C E 1 2 3,M
-128,34 St-Penn Station,A C E 1 2 3,M
+PEN,34 St-Penn Station,A C E 1 2 3,M
 R06,36 Av,N W,Q
 R36,36 St,D N R,Bk
 G20,36 St,M R,Q
 R08,39 Av-Dutch Kills,N W,Q
-F23,4 Av-9 St,R F G,Bk
-R33,4 Av-9 St,R F G,Bk
+4A9,4 Av-9 St,R F G,Bk
 715,40 St-Lowery St,7,Q
-D16,42 St-Bryant Pk,B D F M 7,M
-724,42 St-Bryant Pk,B D F M 7,M
+BRY,42 St-Bryant Pk,B D F M 7,M
 A27,42 St-Port Authority Bus Terminal,A C E,M
 R39,45 St,R N,Bk
 W07,45 St,R N,Bk
@@ -125,8 +112,7 @@ B10,57 St,F,M
 R14,57 St-7 Av,N Q R W,M
 R41,59 St,N R,Bk
 W05,59 St,N R,Bk
-A24,59 St-Columbus Circle,A B C D 1,M
-125,59 St-Columbus Circle,A B C D 1,M
+CLC,59 St-Columbus Circle,A B C D 1,M
 712,61 St-Woodside,7,Q
 B16,62 St,D N,Bk
 G10,63 Dr-Rego Park,M R,Q
@@ -149,7 +135,7 @@ R43,77 St,R,Bk
 B18,79 St,D,Bk
 122,79 St,1,M
 N02,8 Av,N,Bk
-R21,8 St-NYU,R W,M
+NYU,8 St-NYU,R W,M
 A59,80 St,A,Q
 A21,81 St-Museum of Natural History,B C,M
 709,82 St-Jackson Hts,7,Q
@@ -172,13 +158,9 @@ J24,Alabama Av,J,Bk
 H02,Aqueduct-N Conduit Av,A,Q
 636,Astor Pl,6,M
 R03,Astoria Blvd,N W,Q
-W21,Astoria Blvd,N W,Q
 R01,Astoria-Ditmars Blvd,N W,Q
-W22,Astoria-Ditmars Blvd,N W,Q
 L24,Atlantic Av,L,Bk
-D24,Atlantic Av-Barclays Ctr,2 3 4 5 B Q D N R,Bk
-R31,Atlantic Av-Barclays Ctr,2 3 4 5 B Q D N R,Bk
-235,Atlantic Av-Barclays Ctr,2 3 4 5 B Q D N R,Bk
+AAB,Atlantic Av-Barclays Ctr,2 3 4 5 B Q D N R,Bk
 D32,Avenue H,Q,Bk
 F31,Avenue I,F,Bk
 D33,Avenue J,Q,Bk
@@ -212,8 +194,7 @@ F20,Bergen St,F G,Bk
 236,Bergen St,2 3,Bk
 D29,Beverley Rd,Q,Bk
 245,Beverly Rd,2 5,Bk
-423,Borough Hall,2 3 4 5,Bk
-232,Borough Hall,2 3 4 5,Bk
+BOR,Borough Hall,2 3 4 5 R,Bk
 M19,Bowery,J Z,M
 420,Bowling Green,4 5,M
 F05,Briarwood,E F,Q
@@ -227,19 +208,16 @@ J27,Broadway Junction,J Z,Bk
 L22,Broadway Junction,L,Bk
 212,Bronx Park East,2 5,Bx
 618,Brook Av,6,Bx
-640,Brooklyn Bridge-City Hall,4 5 6,M
+640,Brooklyn Bridge-City Hall,4 5 6 J Z,M
 602,Buhre Av,6,Bx
 209,Burke Av,2 5,Bx
 409,Burnside Av,4,Bx
 L21,Bushwick Av-Aberdeen St,L,Bk
-D21,Bway-Lafayette St/Bleecker St,6 B D F M,M
-637,Bway-Lafayette St/Bleecker St,6 B D F M,M
+BWL,Bway-Lafayette St/Bleecker St,6 B D F M,M
+BWL,Bleeker St,6 B D F M,M
 A34,Canal St,A C E,M
-M20,Canal St,6 N Q R W J Z,M
-Q01,Canal St,6 N Q R W J Z,M
+CAN,Canal St,6 N Q R W J Z,M
 135,Canal St,1,M
-R23,Canal St,6 N Q R W J Z,M
-639,Canal St,6 N Q R W J Z,M
 L29,Canarsie-Rockaway Pkwy,L,Bk
 F21,Carroll St,F G,Bk
 607,Castle Hill Av,6,Bx
@@ -247,7 +225,6 @@ A17,Cathedral Pkwy (110 St),B C,M
 118,Cathedral Pkwy (110 St),1,M
 M10,Central Av,M,Bk
 227,Central Park North (110 St),2 3,M
-A36,Chambers St,A C,M
 M21,Chambers St,J Z,M
 137,Chambers St,1 2 3,M
 J28,Chauncey St,J Z,Bk
@@ -256,7 +233,6 @@ D28,Church Av,B Q,Bk
 F27,Church Av,F G,Bk
 244,Church Av,2 5,Bk
 R24,City Hall,R W,M
-W17,City Hall,R W,M
 231,Clark St,2 3,Bk
 G34,Classon Av,G,Bk
 J22,Cleveland St,J,Bk
@@ -265,21 +241,15 @@ G35,Clinton-Washington Avs,G,Bk
 D43,Coney Island-Stillwell Av,D F N Q,Bk
 D30,Cortelyou Rd,Q,Bk
 R25,Cortlandt St,R W,M
-W18,Cortlandt St,R W,M
-W16,Cortlandt St,R W,M
-G22,Court Sq-23 St,7 E M G,Q
-719,Court Sq-23 St,7 E M G,Q
-F09,Court Sq-23 St,7 E M G,Q
-R28,Court St,R,Bk
-W13,Court St,R W,M
+CSQ,Court Sq-23 St,7 E M G,Q
+BOR,Court St,2 3 4 5 R,Bk
 J20,Crescent St,J Z,Bk
 250,Crown Hts-Utica Av,3 4,Bk
 617,Cypress Av,6,Bx
 J19,Cypress Hills,J,Bk
 R30,DeKalb Av,B Q R,Bk
 L16,DeKalb Av,L,Bk
-F15,Delancey St-Essex St,J Z F M,M
-M18,Delancey St-Essex St,J Z F M,M
+ESX,Delancey St-Essex St,J Z F M,M
 F29,Ditmas Av,F,Bk
 A03,Dyckman St,A,M
 109,Dyckman St,1,M
@@ -305,31 +275,24 @@ G08,Forest Hills-71 Av,E F M R,Q
 B13,Fort Hamilton Pkwy,D,Bk
 F26,Fort Hamilton Pkwy,F G,Bk
 N03,Fort Hamilton Pkwy,N,Bk
-A45,Franklin Av/Botanic Garden,2 3 4 5 C Sf,Bk
 S01,Franklin Avenue,C Sf,Bk
-239,Franklin Avenue/Botanic Garden,2 3 4 5 Sf,Bk
-S04,Franklin Avenue/Botanic Garden,2 3 4 5 Sf,Bk
+BOT,Franklin Avenue/Botanic Garden,2 3 4 5 Sf,Bk
+BOT,Franklin Avenue-Medgar Evers College,2 3 4 5 Sf,Bk
 136,Franklin St,1,M
 216,Freeman St,2 5,Bx
 M04,Fresh Pond Rd,M,Q
-A38,Fulton St,2 3 4 5 A C J Z,M
-418,Fulton St,2 3 4 5 A C J Z,M
 G36,Fulton St,G,Bk
-M22,Fulton St,2 3 4 5 A C J Z,M
-229,Fulton St,2 3 4 5 A C J Z,M
+FUL,Fulton St,2 3 4 5 A C J Z,M
 J30,Gates Av,J Z,Bk
 L11,Graham Av,L,Bk
 237,Grand Army Plaza,2 3,Bk
 G12,Grand Av-Newtown,M R,Q
-631,Grand Central-42 St,4 5 6 7 S,M
-901,Grand Central-42 St,4 5 6 7 S,M
-723,Grand Central-42 St,4 5 6 7 S,M
+GRC,Grand Central-42 St,4 5 6 7 S,M
 D22,Grand St,B D,M
 L12,Grand St,L,Bk
 A57,Grant Av,A,Bk
 G26,Greenpoint Av,G,Bk
 208,Gun Hill Rd,2 5,Bx
-503,Gun Hill Rd,2 5,Bx
 J29,Halsey St,J,Bk
 L19,Halsey St,L,Q
 301,Harlem-148 St,3,M
@@ -344,14 +307,11 @@ A42,Hoyt-Schermerhorn Sts,A C G,Bk
 218,Intervale Av,2 5,Bx
 A02,Inwood-207 St,A,M
 220,Jackson Av,2 5,Bx
-G14,Jackson Hts-Roosevelt Av,7 E F M R,Q
 710,Jackson Hts-Roosevelt Av,7 E F M R,Q
 G05,Jamaica Center-Parsons/Archer,E,Q
 F01,Jamaica-179 St,F,Q
 G07,Jamaica-Van Wyck,E,Q
-A41,Jay St-MetroTech,A C F R,Bk
-R29,Jay St-MetroTech,A C F R,Bk
-W12,Jay St-MetroTech,A C F R,Bk
+JAY,Jay St-MetroTech,A C F R,Bk
 L15,Jefferson St,L,Bk
 707,Junction Blvd,7,Q
 254,Junius St,3,Bk
@@ -367,10 +327,8 @@ M09,Knickerbocker Av,M,Bk
 J31,Kosciuszko St,J,Bk
 A43,Lafayette Av,C,Bk
 F11,Lexington Av/53 St,E M 6,M
-630,Lexington Av/53 St,E M 6,M
 R11,Lexington Av/59 St,N R W 4 5 6,M
 B08,Lexington Av/63 St,F Q,M
-629,Lexington Av/59 St,N R W 4 5 6,M
 A52,Liberty Av,C,Bk
 L26,Livonia Av,L,Bk
 614,Longwood Av,6,Bx
@@ -424,14 +382,10 @@ R22,Prince St,R W,M
 R34,Prospect Av,R,Bk
 D26,Prospect Park,B Q Sf,Bk
 G21,Queens Plaza,E M R,Q
-R09,Queensboro Plaza,7 N W,Q
-718,Queensboro Plaza,7 N W,Q
 QBP,Queensboro Plaza,7 N W,Q
 A49,Ralph Av,C,Bk
 139,Rector St,1,M
 R26,Rector St,R W,M
-W19,Rector St,R W,M
-W15,Rector St,R W,M
 A50,Rockaway Av,C,Bk
 253,Rockaway Av,3,Bk
 A61,Rockaway Blvd,A,Q
@@ -443,7 +397,7 @@ D39,Sheepshead Bay,B Q,Bk
 A54,Shepherd Av,C,Bk
 217,Simpson St,2 5,Bx
 F22,Smith-9 Sts,F G,Bk
-142,Whitehall St-South Ferry,1 R W,M
+R27,South Ferry,1 R W,M
 A33,Spring St,C E,M
 638,Spring St,6,M
 609,St Lawrence Av,6,Bx
@@ -453,10 +407,7 @@ F04,Sutphin Blvd,F,Q
 G06,Sutphin Blvd-Archer Av-JFK Airport,E J Z,Q
 L25,Sutter Av,L,Bk
 251,Sutter Av-Rutland Rd,3,Bk
-R16,Times Sq-42 St,1 2 3 7 N Q R W S,M
 127,Times Sq-42 St,1 2 3 7 N Q R W S,M
-902,Times Sq-42 St,1 2 3 7 N Q R W S,M
-725,Times Sq-42 St,1 2 3 7 N Q R W S,M
 D07,Tremont Av,B D,Bx
 R32,Union St,R,Bk
 A48,Utica Av,A C,Bk
@@ -466,7 +417,6 @@ J23,Van Siclen Av,J Z,Bk
 256,Van Siclen Av,3,Bk
 721,Vernon Blvd-Jackson Av,7,Q
 A32,W 4 St-Wash Sq,A C E B D F M,M
-D20,W 4 St-Wash Sq,A C E B D F M,M
 D42,W 8 St-NY Aquarium,F Q,Bk
 201,Wakefield-241 St,2,Bx
 419,Wall St,4 5,M
@@ -474,8 +424,6 @@ D42,W 8 St-NY Aquarium,F Q,Bk
 214,West Farms Sq-E Tremont Av,2 5,Bx
 604,Westchester Sq-E Tremont Av,6,Bx
 R27,Whitehall St-South Ferry,1 R W,M
-W20,Whitehall St-South Ferry,1 R W,M
-W14,Whitehall St-South Ferry,1 R W,M
 612,Whitlock Av,6,Bx
 L20,Wilson Av,L,Bk
 243,Winthrop St,2 5,Bk

--- a/public/csv/b_train_stations.csv
+++ b/public/csv/b_train_stations.csv
@@ -6,16 +6,16 @@ D31,Newkirk Plaza,B Q,Bk
 D28,Church Av,B Q,Bk
 D26,Prospect Park,B Q Sf,Bk
 D25,7 Av,B Q,Bk
-D24,Atlantic Av-Barclays Ctr,2 3 4 5 B Q D N R,Bk
+AAB,Atlantic Av-Barclays Ctr,2 3 4 5 B Q D N R,Bk
 R30,DeKalb Av,B Q R,Bk
 D22,Grand St,B D,M
-D21,Bway-Lafayette St/Bleecker St,6 B D F M,M
-D20,W 4 St-Wash Sq,A C E B D F M,M
-D17,34 St-Herald Sq,B D F M N Q R W,M
-D16,42 St-Bryant Pk,B D F M 7,M
+BWL,Bway-Lafayette St/Bleecker St,6 B D F M,M
+A32,W 4 St-Wash Sq,A C E B D F M,M
+HSQ,34 St-Herald Sq,B D F M N Q R W,M
+BRY,42 St-Bryant Pk,B D F M 7,M
 D15,47-50 Sts-Rockefeller Ctr,B D F M,M
 D14,7 Av,B D E,M
-A24,59 St-Columbus Circle,A B C D 1,M
+CLC,59 St-Columbus Circle,A B C D 1,M
 A22,72 St,B C,M
 A21,81 St-Museum of Natural History,B C,M
 A20,86 St,B C,M
@@ -25,9 +25,9 @@ A17,Cathedral Pkwy (110 St),B C,M
 A16,116 St,B C,M
 A15,125 St,A C B D,M
 A14,135 St,B C,M
-D13,145 St,A C B D,M
+A12,145 St,A C B D,M
 D12,155 St,B D,M
-D11,161 St-Yankee Stadium,B D,Bx
+NYY,161 St-Yankee Stadium,B D 4,Bx
 D10,167 St,B D,Bx
 D09,170 St,B D,Bx
 D08,174-175 Sts,B D,Bx

--- a/public/csv/c_train_stations.csv
+++ b/public/csv/c_train_stations.csv
@@ -13,19 +13,19 @@ A45,Franklin Avenue,C Sf,Bk
 A44,Clinton-Washington Avs,C,Bk
 A43,Lafayette Av,C,Bk
 A42,Hoyt-Schermerhorn Sts,A C G,Bk
-A41,Jay St-MetroTech,A C F R,Bk
+JAY,Jay St-MetroTech,A C F R,Bk
 A40,High St,A C,Bk
-A38,Fulton St,2 3 4 5 A C J Z,M
+FUL,Fulton St,2 3 4 5 A C J Z,M
 A36,Chambers St,A C,M
 A34,Canal St,A C E,M
 A33,Spring St,C E,M
 A32,W 4 St-Wash Sq,A C E B D F M,M
-A31,14 St (8th Av),A C E L,M
+L01,14 St (8th Av),A C E L,M
 A30,23 St,C E,M
-A28,34 St-Penn Station,A C E 1 2 3,M
+PEN,34 St-Penn Station,A C E 1 2 3,M
 A27,42 St-Port Authority Bus Terminal,A C E,M
 A25,50 St,C E,M
-A24,59 St-Columbus Circle,A B C D 1,M
+CLC,59 St-Columbus Circle,A B C D 1,M
 A22,72 St,B C,M
 A21,81 St-Museum of Natural History,B C,M
 A20,86 St,B C,M

--- a/public/csv/d_train_stations.csv
+++ b/public/csv/d_train_stations.csv
@@ -13,19 +13,19 @@ B14,50 St,D,Bk
 B13,Fort Hamilton Pkwy,D,Bk
 B12,9 Av,D,Bk
 R36,36 St,D N R,Bk
-R31,Atlantic Av-Barclays Ctr,2 3 4 5 B Q D N R,Bk
+AAB,Atlantic Av-Barclays Ctr,2 3 4 5 B Q D N R,Bk
 D22,Grand St,B D,M
-D21,Bway-Lafayette St/Bleecker St,6 B D F M,M
-D20,W 4 St-Wash Sq,A C E B D F M,M
-D17,34 St-Herald Sq,B D F M N Q R W,M
-D16,42 St-Bryant Pk,B D F M 7,M
+BWL,Bway-Lafayette St/Bleecker St,6 B D F M,M
+A32,W 4 St-Wash Sq,A C E B D F M,M
+HSQ,34 St-Herald Sq,B D F M N Q R W,M
+BRY,42 St-Bryant Pk,B D F M 7,M
 D15,47-50 Sts-Rockefeller Ctr,B D F M,M
 D14,7 Av,B D E,M
-A24,59 St-Columbus Circle,A B C D 1,M
+CLC,59 St-Columbus Circle,A B C D 1,M
 A15,125 St,A C B D,M
-D13,145 St,A C B D,M
+A12,145 St,A C B D,M
 D12,155 St,B D,M
-D11,161 St-Yankee Stadium,B D,Bx
+NYY,161 St-Yankee Stadium,B D 4,Bx
 D10,167 St,B D,Bx
 D09,170 St,B D,Bx
 D08,174-175 Sts,B D,Bx

--- a/public/csv/e_train_stations.csv
+++ b/public/csv/e_train_stations.csv
@@ -3,17 +3,17 @@ E01,World Trade Center,E,M
 A34,Canal St,A C E,M
 A33,Spring St,C E,M
 A32,W 4 St-Wash Sq,A C E B D F M,M
-A31,14 St (8th Av),A C E L,M
+L01,14 St (8th Av),A C E L,M
 A30,23 St,C E,M
-A28,34 St-Penn Station,A C E 1 2 3,M
+PEN,34 St-Penn Station,A C E 1 2 3,M
 A27,42 St-Port Authority Bus Terminal,A C E,M
 A25,50 St,C E,M
 D14,7 Av,B D E,M
 F12,5 Av/53 St,E M,M
 F11,Lexington Av/53 St,E M 6,M
-F09,Court Sq-23 St,7 E M G,Q
+CSQ,Court Sq-23 St,7 E M G,Q
 G21,Queens Plaza,E M R,Q
-G14,Jackson Hts-Roosevelt Av,7 E F M R,Q
+710,Jackson Hts-Roosevelt Av,7 E F M R,Q
 G08,Forest Hills-71 Av,E F M R,Q
 F07,75 Av,E F,Q
 F06,Kew Gardens-Union Tpke,E F,Q

--- a/public/csv/f_train_stations.csv
+++ b/public/csv/f_train_stations.csv
@@ -15,27 +15,27 @@ F27,Church Av,F G,Bk
 F26,Fort Hamilton Pkwy,F G,Bk
 F25,15 St-Prospect Park,F G,Bk
 F24,7 Av,F G,Bk
-F23,4 Av-9 St,R F G,Bk
+4A9,4 Av-9 St,R F G,Bk
 F22,Smith-9 Sts,F G,Bk
 F21,Carroll St,F G,Bk
 F20,Bergen St,F G,Bk
-A41,Jay St-MetroTech,A C F R,Bk
+JAY,Jay St-MetroTech,A C F R,Bk
 F18,York St,F,Bk
 F16,East Broadway,F,M
-F15,Delancey St-Essex St,J Z F M,M
+ESX,Delancey St-Essex St,J Z F M,M
 F14,2 Av,F,M
-D21,Bway-Lafayette St/Bleecker St,6 B D F M,M
-D20,W 4 St-Wash Sq,A C E B D F M,M
-D19,14 St (6th Av),1 2 3 F M L,M
+BWL,Bway-Lafayette St/Bleecker St,6 B D F M,M
+A32,W 4 St-Wash Sq,A C E B D F M,M
+132,14 St (6th Av),1 2 3 F M L,M
 D18,23 St,F M,M
-D17,34 St-Herald Sq,B D F M N Q R W,M
-D16,42 St-Bryant Pk,B D F M 7,M
+HSQ,34 St-Herald Sq,B D F M N Q R W,M
+BRY,42 St-Bryant Pk,B D F M 7,M
 D15,47-50 Sts-Rockefeller Ctr,B D F M,M
 B10,57 St,F,M
 B08,Lexington Av/63 St,F Q,M
 B06,Roosevelt Island,F,M
 B04,21 St-Queensbridge,F,Q
-G14,Jackson Hts-Roosevelt Av,7 E F M R,Q
+710,Jackson Hts-Roosevelt Av,7 E F M R,Q
 G08,Forest Hills-71 Av,E F M R,Q
 F07,75 Av,E F,Q
 F06,Kew Gardens-Union Tpke,E F,Q

--- a/public/csv/five_train_stations.csv
+++ b/public/csv/five_train_stations.csv
@@ -6,21 +6,21 @@ stop_id,stop_name,transfers,borough
 243,Winthrop St,2 5,Bk
 242,Sterling St,2 5,Bk
 241,President St-Medgar Evers College,2 5,Bk
-239,Franklin Avenue/Botanic Garden,2 3 4 5 Sf,Bk
-235,Atlantic Av-Barclays Ctr,2 3 4 5 B Q D N R,Bk
+BOT,Franklin Avenue-Medgar Evers College,2 3 4 5 Sf,Bk
+AAB,Atlantic Av-Barclays Ctr,2 3 4 5 B Q D N R,Bk
 234,Nevins St,2 3 4 5,Bk
-423,Borough Hall,2 3 4 5,Bk
+BOR,Borough Hall,2 3 4 5 R,Bk
 420,Bowling Green,4 5,M
 419,Wall St,4 5,M
-418,Fulton St,2 3 4 5 A C J Z,M
+FUL,Fulton St,2 3 4 5 A C J Z,M
 640,Brooklyn Bridge-City Hall,4 5 6 J Z,M
-635,14 St-Union Sq,4 5 6 N Q R W L,M
-631,Grand Central-42 St,4 5 6 7 S,M
-629,Lexington Av/59 St,N R W 4 5 6,M
+USQ,14 St-Union Sq,4 5 6 N Q R W L,M
+GRC,Grand Central-42 St,4 5 6 7 S,M
+R11,Lexington Av/59 St,N R W 4 5 6,M
 626,86 St,4 5 6,M
 621,125 St,4 5 6,M
 416,138 St-Grand Concourse,4 5,Bx
-222,149 St-Grand Concourse,2 5,Bx
+222,149 St-Grand Concourse,2 4 5,Bx
 221,3 Av-149 St,2 5,Bx
 220,Jackson Av,2 5,Bx
 219,Prospect Av,2 5,Bx
@@ -41,6 +41,5 @@ stop_id,stop_name,transfers,borough
 204,Nereid Av,2 5,Bx
 505,Morris Park,5,Bx
 504,Pelham Pkwy,5,Bx
-503,Gun Hill Rd,2 5,Bx
 502,Baychester Av,5,Bx
 501,Eastchester-Dyre Av,5,Bx

--- a/public/csv/four_train_stations.csv
+++ b/public/csv/four_train_stations.csv
@@ -1,21 +1,21 @@
 stop_id,stop_name,transfers,borough
 250,Crown Hts-Utica Av,3 4,Bk
-239,Franklin Avenue/Botanic Garden,2 3 4 5 Sf,Bk
-235,Atlantic Av-Barclays Ctr,2 3 4 5 B Q D N R,Bk
+BOT,Franklin Avenue-Medgar Evers College,2 3 4 5 Sf,Bk
+AAB,Atlantic Av-Barclays Ctr,2 3 4 5 B Q D N R,Bk
 234,Nevins St,2 3 4 5,Bk
-423,Borough Hall,2 3 4 5,Bk
+BOR,Borough Hall,2 3 4 5 R,Bk
 420,Bowling Green,4 5,M
 419,Wall St,4 5,M
-418,Fulton St,2 3 4 5 A C J Z,M
-640,Brooklyn Bridge-City Hall,4 5 6,M
-635,14 St-Union Sq,4 5 6 N Q R W L,M
-631,Grand Central-42 St,4 5 6 7 S,M
-629,Lexington Av/59 St,N R W 4 5 6,M
+FUL,Fulton St,2 3 4 5 A C J Z,M
+640,Brooklyn Bridge-City Hall,4 5 6 J Z,M
+USQ,14 St-Union Sq,4 5 6 N Q R W L,M
+GRC,Grand Central-42 St,4 5 6 7 S,M
+R11,Lexington Av/59 St,N R W 4 5 6,M
 626,86 St,4 5 6,M
 621,125 St,4 5 6,M
 416,138 St-Grand Concourse,4 5,Bx
-415,149 St-Grand Concourse,4,Bx
-414,161 St-Yankee Stadium,4,Bx
+222,149 St-Grand Concourse,2 4 5,Bx
+NYY,161 St-Yankee Stadium,B D 4,Bx
 413,167 St,4,Bx
 412,170 St,4,Bx
 411,Mt Eden Av,4,Bx

--- a/public/csv/g_train_stations.csv
+++ b/public/csv/g_train_stations.csv
@@ -3,7 +3,7 @@ F27,Church Av,F G,Bk
 F26,Fort Hamilton Pkwy,F G,Bk
 F25,15 St-Prospect Park,F G,Bk
 F24,7 Av,F G,Bk
-F23,4 Av-9 St,R F G,Bk
+4A9,4 Av-9 St,R F G,Bk
 F22,Smith-9 Sts,F G,Bk
 F21,Carroll St,F G,Bk
 F20,Bergen St,F G,Bk
@@ -19,4 +19,4 @@ G29,Metropolitan Av,G,Bk
 G28,Nassau Av,G,Bk
 G26,Greenpoint Av,G,Bk
 G24,21 St,G,Q
-G22,Court Sq-23 St,7 E M G,Q
+CSQ,Court Sq,7 E M G,Q

--- a/public/csv/j_train_stations.csv
+++ b/public/csv/j_train_stations.csv
@@ -1,10 +1,10 @@
 stop_id,stop_name,transfers,borough
 M23,Broad St,J Z,M
-M22,Fulton St,2 3 4 5 A C J Z,M
+FUL,Fulton St,2 3 4 5 A C J Z,M
 M21,Chambers St,J Z,M
-M20,Canal St,6 N Q R W J Z,M
+CAN,Canal St,6 N Q R W J Z,M
 M19,Bowery,J Z,M
-M18,Delancey St-Essex St,J Z F M,M
+ESX,Delancey St-Essex St,J Z F M,M
 M16,Marcy Av,J M Z,Bk
 M14,Hewes St,J M,Bk
 M13,Lorimer St,J M,Bk

--- a/public/csv/l_train_stations.csv
+++ b/public/csv/l_train_stations.csv
@@ -20,6 +20,6 @@ L10,Lorimer St,L,Bk
 L08,Bedford Av,L,Bk
 L06,1 Av,L,M
 L05,3 Av,L,M
-L03,14 St-Union Sq,4 5 6 N Q R W L,M
-L02,14 St (6th Av),1 2 3 F M L,M
+USQ,14 St-Union Sq,4 5 6 N Q R W L,M
+132,14 St (6th Av),1 2 3 F M L,M
 L01,14 St (8th Av),A C E L,M

--- a/public/csv/m_train_stations.csv
+++ b/public/csv/m_train_stations.csv
@@ -11,24 +11,24 @@ M12,Flushing Av,J M,Bk
 M13,Lorimer St,J M,Bk
 M14,Hewes St,J M,Bk
 M16,Marcy Av,J M Z,Bk
-M18,Delancey St-Essex St,J Z F M,M
-D21,Bway-Lafayette St/Bleecker St,6 B D F M,M
-D20,W 4 St-Wash Sq,A C E B D F M,M
-D19,14 St (6th Av),1 2 3 F M L,M
+ESX,Delancey St-Essex St,J Z F M,M
+BWL,Bway-Lafayette St/Bleecker St,6 B D F M,M
+A32,W 4 St-Wash Sq,A C E B D F M,M
+132,14 St (6th Av),1 2 3 F M L,M
 D18,23 St,F M,M
-D17,34 St-Herald Sq,B D F M N Q R W,M
-D16,42 St-Bryant Pk,B D F M 7,M
+HSQ,34 St-Herald Sq,B D F M N Q R W,M
+BRY,42 St-Bryant Pk,B D F M 7,M
 D15,47-50 Sts-Rockefeller Ctr,B D F M,M
 F12,5 Av/53 St,E M,M
 F11,Lexington Av/53 St,E M 6,M
-F09,Court Sq-23 St,7 E M G,Q
+CSQ,Court Sq-23 St,7 E M G,Q
 G21,Queens Plaza,E M R,Q
 G20,36 St,M R,Q
 G19,Steinway St,M R,Q
 G18,46 St,M R,Q
 G16,Northern Blvd,M R,Q
 G15,65 St,M R,Q
-G14,Jackson Hts-Roosevelt Av,7 E F M R,Q
+710,Jackson Hts-Roosevelt Av,7 E F M R,Q
 G13,Elmhurst Av,M R,Q
 G12,Grand Av-Newtown,M R,Q
 G11,Woodhaven Blvd,M R,Q

--- a/public/csv/n_train_stations.csv
+++ b/public/csv/n_train_stations.csv
@@ -11,16 +11,16 @@ N03,Fort Hamilton Pkwy,N,Bk
 N02,8 Av,N,Bk
 R41,59 St,N R,Bk
 R36,36 St,D N R,Bk
-R31,Atlantic Av-Barclays Ctr,2 3 4 5 B Q D N R,Bk
-Q01,Canal St,6 N Q R W J Z,M
-R20,14 St-Union Sq,4 5 6 N Q R W L,M
-R17,34 St-Herald Sq,B D F M N Q R W,M
-R16,Times Sq-42 St,1 2 3 7 N Q R W S,M
+AAB,Atlantic Av-Barclays Ctr,2 3 4 5 B Q D N R,Bk
+CAN,Canal St,6 N Q R W J Z,M
+USQ,14 St-Union Sq,4 5 6 N Q R W L,M
+HSQ,34 St-Herald Sq,B D F M N Q R W,M
+127,Times Sq-42 St,1 2 3 7 N Q R W S,M
 R15,49 St,N R W,M
 R14,57 St-7 Av,N Q R W,M
 R13,5 Av/59 St,N R W,M
 R11,Lexington Av/59 St,N R W 4 5 6,M
-R09,Queensboro Plaza,7 N W,Q
+QBP,Queensboro Plaza,7 N W,Q
 R08,39 Av-Dutch Kills,N W,Q
 R06,36 Av,N W,Q
 R05,Broadway,N W,Q

--- a/public/csv/one_train_stations.csv
+++ b/public/csv/one_train_stations.csv
@@ -1,5 +1,5 @@
 stop_id,stop_name,transfers,borough
-142,Whitehall St-South Ferry,1 R W,M
+R27,South Ferry,1 R W,M
 139,Rector St,1,M
 138,WTC Cortlandt,1,M
 137,Chambers St,1 2 3,M
@@ -11,10 +11,10 @@ stop_id,stop_name,transfers,borough
 131,18 St,1,M
 130,23 St,1,M
 129,28 St,1,M
-128,34 St-Penn Station,A C E 1 2 3,M
+PEN,34 St-Penn Station,A C E 1 2 3,M
 127,Times Sq-42 St,1 2 3 7 N Q R W S,M
 126,50 St,1,M
-125,59 St-Columbus Circle,A B C D 1,M
+CLC,59 St-Columbus Circle,A B C D 1,M
 124,66 St-Lincoln Center,1,M
 123,72 St,1 2 3,M
 122,79 St,1,M
@@ -27,7 +27,7 @@ stop_id,stop_name,transfers,borough
 115,137 St-City College,1,M
 114,145 St,1,M
 113,157 St,1,M
-112,168 St,A C 1,M
+A09,168 St,A C 1,M
 111,181 St,1,M
 110,191 St,1,M
 109,Dyckman St,1,M

--- a/public/csv/q_train_stations.csv
+++ b/public/csv/q_train_stations.csv
@@ -17,12 +17,12 @@ D28,Church Av,B Q,Bk
 D27,Parkside Av,Q,Bk
 D26,Prospect Park,B Q Sf,Bk
 D25,7 Av,B Q,Bk
-D24,Atlantic Av-Barclays Ctr,2 3 4 5 B Q D N R,Bk
+AAB,Atlantic Av-Barclays Ctr,2 3 4 5 B Q D N R,Bk
 R30,DeKalb Av,B Q R,Bk
-Q01,Canal St,6 N Q R W J Z,M
-R20,14 St-Union Sq,4 5 6 N Q R W L,M
-R17,34 St-Herald Sq,B D F M N Q R W,M
-R16,Times Sq-42 St,1 2 3 7 N Q R W S,M
+CAN,Canal St,6 N Q R W J Z,M
+USQ,14 St-Union Sq,4 5 6 N Q R W L,M
+HSQ,34 St-Herald Sq,B D F M N Q R W,M
+127,Times Sq-42 St,1 2 3 7 N Q R W S,M
 R14,57 St-7 Av,N Q R W,M
 B08,Lexington Av/63 St,F Q,M
 Q03,72 St,Q,M

--- a/public/csv/r_train_stations.csv
+++ b/public/csv/r_train_stations.csv
@@ -9,24 +9,24 @@ R39,45 St,R,Bk
 R36,36 St,D N R,Bk
 R35,25 St,R,Bk
 R34,Prospect Av,R,Bk
-R33,4 Av-9 St,R F G,Bk
+4A9,4 Av-9 St,R F G,Bk
 R32,Union St,R,Bk
-R31,Atlantic Av-Barclays Ctr,2 3 4 5 B Q D N R,Bk
+AAB,Atlantic Av-Barclays Ctr,2 3 4 5 B Q D N R,Bk
 R30,DeKalb Av,B Q R,Bk
-R29,Jay St-MetroTech,A C F R,Bk
-R28,Court St,R,Bk
-R27,Whitehall St-South Ferry,R W,M
+JAY,Jay St-MetroTech,A C F R,Bk
+BOR,Court St,2 3 4 5 R,Bk
+R27,Whitehall St-South Ferry,1 R W,M
 R26,Rector St,R W,M
 R25,Cortlandt St,R W,M
 R24,City Hall,R W,M
-R23,Canal St,6 N Q R W J Z,M
+CAN,Canal St,6 N Q R W J Z,M
 R22,Prince St,R W,M
-R21,8 St-NYU,R W,M
-R20,14 St-Union Sq,4 5 6 N Q R W L,M
+NYU,8 St-NYU,R W,M
+USQ,14 St-Union Sq,4 5 6 N Q R W L,M
 R19,23 St,R W,M
 R18,28 St,R W,M
-R17,34 St-Herald Sq,B D F M N Q R W,M
-R16,Times Sq-42 St,1 2 3 7 N Q R W S,M
+HSQ,34 St-Herald Sq,B D F M N Q R W,M
+127,Times Sq-42 St,1 2 3 7 N Q R W S,M
 R15,49 St,N R W,M
 R14,57 St-7 Av,N Q R W,M
 R13,5 Av/59 St,N R W,M
@@ -37,7 +37,7 @@ G19,Steinway St,M R,Q
 G18,46 St,M R,Q
 G16,Northern Blvd,M R,Q
 G15,65 St,M R,Q
-G14,Jackson Hts-Roosevelt Av,7 E F M R,Q
+710,Jackson Hts-Roosevelt Av,7 E F M R,Q
 G13,Elmhurst Av,M R,Q
 G12,Grand Av-Newtown,M R,Q
 G11,Woodhaven Blvd,M R,Q

--- a/public/csv/s_train_shuttle_stations.csv
+++ b/public/csv/s_train_shuttle_stations.csv
@@ -1,5 +1,5 @@
 stop_id,stop_name,transfers,borough
 S01,Franklin Avenue,C Sf,Bk
 S03,Park Pl,Sf,Bk
-S04,Franklin Avenue/Botanic Garden,2 3 4 5 Sf,Bk
+BOT,Botanic Garden,2 3 4 5 Sf,Bk
 D26,Prospect Park,B Q Sf,Bk

--- a/public/csv/s_train_stations.csv
+++ b/public/csv/s_train_stations.csv
@@ -1,3 +1,3 @@
 stop_id,stop_name,transfers,borough
-902,Times Sq-42 St,1 2 3 7 N Q R W S,M
-901,Grand Central-42 St,4 5 6 7 S,M
+127,Times Sq-42 St,1 2 3 7 N Q R W S,M
+GRC,Grand Central-42 St,4 5 6 7 S,M

--- a/public/csv/seven_train_stations.csv
+++ b/public/csv/seven_train_stations.csv
@@ -1,12 +1,12 @@
 stop_id,stop_name,transfers,borough
 726,34 St-Hudson Yards,7,M
-725,Times Sq-42 St,1 2 3 7 N Q R W S,M
-724,42 St-Bryant Pk,B D F M 7,M
-723,Grand Central-42 St,4 5 6 7 S,M
+127,Times Sq-42 St,1 2 3 7 N Q R W S,M
+BRY,42 St-Bryant Pk,B D F M 7,M
+GRC,Grand Central-42 St,4 5 6 7 S,M
 721,Vernon Blvd-Jackson Av,7,Q
 720,Hunters Point Av,7,Q
-719,Court Sq-23 St,7 E M G,Q
-718,Queensboro Plaza,7 N W,Q
+CSQ,Court Sq,7 E M G,Q
+QBP,Queensboro Plaza,7 N W,Q
 716,33 St-Rawson St,7,Q
 715,40 St-Lowery St,7,Q
 714,46 St-Bliss St,7,Q

--- a/public/csv/six_train_stations.csv
+++ b/public/csv/six_train_stations.csv
@@ -1,16 +1,16 @@
 stop_id,stop_name,transfers,borough
-640,Brooklyn Bridge-City Hall,4 5 6,M
-639,Canal St,6 N Q R W J Z,M
+640,Brooklyn Bridge-City Hall,4 5 6 J Z,M
+CAN,Canal St,6 N Q R W J Z,M
 638,Spring St,6,M
-637,Bway-Lafayette St/Bleecker St,6 B D F M,M
+BWL,Bleeker St,6 B D F M,M
 636,Astor Pl,6,M
-635,14 St-Union Sq,4 5 6 N Q R W L,M
+USQ,14 St-Union Sq,4 5 6 N Q R W L,M
 634,23 St,6,M
 633,28 St,6,M
 632,33 St,6,M
-631,Grand Central-42 St,4 5 6 7 S,M
-630,Lexington Av/53 St,E M 6,M
-629,Lexington Av/59 St,N R W 4 5 6,M
+GRC,Grand Central-42 St,4 5 6 7 S,M
+F11,Lexington Av/53 St,E M 6,M
+R11,Lexington Av/59 St,N R W 4 5 6,M
 628,68 St-Hunter College,6,M
 627,77 St,6,M
 626,86 St,4 5 6,M

--- a/public/csv/three_train_stations.csv
+++ b/public/csv/three_train_stations.csv
@@ -9,21 +9,21 @@ stop_id,stop_name,transfers,borough
 250,Crown Hts-Utica Av,3 4,Bk
 249,Kingston Av,3,Bk
 248,Nostrand Av,3,Bk
-239,Franklin Avenue/Botanic Garden,2 3 4 5 Sf,Bk
+BOT,Franklin Avenue-Medgar Evers College,2 3 4 5 Sf,Bk
 238,Eastern Pkwy-Brooklyn Museum,2 3,Bk
 237,Grand Army Plaza,2 3,Bk
 236,Bergen St,2 3,Bk
-235,Atlantic Av-Barclays Ctr,2 3 4 5 B Q D N R,Bk
+AAB,Atlantic Av-Barclays Ctr,2 3 4 5 B Q D N R,Bk
 234,Nevins St,2 3 4 5,Bk
 233,Hoyt St,2 3,Bk
-232,Borough Hall,2 3 4 5,Bk
+BOR,Borough Hall,2 3 4 5 R,Bk
 231,Clark St,2 3,Bk
 230,Wall St,2 3,M
-229,Fulton St,2 3 4 5 A C J Z,M
+FUL,Fulton St,2 3 4 5 A C J Z,M
 228,Park Place,2 3,M
 137,Chambers St,1 2 3,M
 132,14 St (6th Av),1 2 3 F M L,M
-128,34 St-Penn Station,A C E 1 2 3,M
+PEN,34 St-Penn Station,A C E 1 2 3,M
 127,Times Sq-42 St,1 2 3 7 N Q R W S,M
 123,72 St,1 2 3,M
 120,96 St,1 2 3,M

--- a/public/csv/two_train_stations.csv
+++ b/public/csv/two_train_stations.csv
@@ -6,21 +6,21 @@ stop_id,stop_name,transfers,borough
 243,Winthrop St,2 5,Bk
 242,Sterling St,2 5,Bk
 241,President St-Medgar Evers College,2 5,Bk
-239,Franklin Avenue/Botanic Garden,2 3 4 5 Sf,Bk
+BOT,Franklin Avenue-Medgar Evers College,2 3 4 5 Sf,Bk
 238,Eastern Pkwy-Brooklyn Museum,2 3,Bk
 237,Grand Army Plaza,2 3,Bk
 236,Bergen St,2 3,Bk
-235,Atlantic Av-Barclays Ctr,2 3 4 5 B Q D N R,Bk
+AAB,Atlantic Av-Barclays Ctr,2 3 4 5 B Q D N R,Bk
 234,Nevins St,2 3 4 5,Bk
 233,Hoyt St,2 3,Bk
-232,Borough Hall,2 3 4 5,Bk
+BOR,Borough Hall,2 3 4 5 R,Bk
 231,Clark St,2 3,Bk
 230,Wall St,2 3,M
-229,Fulton St,2 3 4 5 A C J Z,M
+FUL,Fulton St,2 3 4 5 A C J Z,M
 228,Park Place,2 3,M
 137,Chambers St,1 2 3,M
 132,14 St (6th Av),1 2 3 F M L,M
-128,34 St-Penn Station,A C E 1 2 3,M
+PEN,34 St-Penn Station,A C E 1 2 3,M
 127,Times Sq-42 St,1 2 3 7 N Q R W S,M
 123,72 St,1 2 3,M
 120,96 St,1 2 3,M
@@ -28,7 +28,7 @@ stop_id,stop_name,transfers,borough
 226,116 St,2 3,M
 225,125 St,2 3,M
 224,135 St,2 3,M
-222,149 St-Grand Concourse,2 5,Bx
+222,149 St-Grand Concourse,2 4 5,Bx
 221,3 Av-149 St,2 5,Bx
 220,Jackson Av,2 5,Bx
 219,Prospect Av,2 5,Bx

--- a/public/csv/w_train_stations.csv
+++ b/public/csv/w_train_stations.csv
@@ -1,23 +1,23 @@
 stop_id,stop_name,transfers,borough
-W27,Whitehall St-South Ferry,R W,M
-W26,Rector St,R W,M
-W25,Cortlandt St,R W,M
-W24,City Hall,R W,M
-W23,Canal St,6 N Q R W J Z,M
-W22,Prince St,R W,M
-W21,8 St-NYU,R W,M
-W20,14 St-Union Sq,4 5 6 N Q R W L,M
-W19,23 St,R W,M
-W18,28 St,R W,M
-W17,34 St-Herald Sq,B D F M N Q R W,M
-W16,Times Sq-42 St,1 2 3 7 N Q R W S,M
-W15,49 St,N R W,M
-W14,57 St-7 Av,N Q R W,M
-W13,5 Av/59 St,N R W,M
-W12,Lexington Av/59 St,N R W 4 5 6,M
+R27,Whitehall St-South Ferry,1 R W,M
+R26,Rector St,R W,M
+R25,Cortlandt St,R W,M
+R24,City Hall,R W,M
+CAN,Canal St,6 N Q R W J Z,M
+R22,Prince St,R W,M
+NYU,8 St-NYU,R W,M
+USQ,14 St-Union Sq,4 5 6 N Q R W L,M
+R19,23 St,R W,M
+R18,28 St,R W,M
+HSQ,34 St-Herald Sq,B D F M N Q R W,M
+127,Times Sq-42 St,1 2 3 7 N Q R W S,M
+R15,49 St,N R W,M
+R14,57 St-7 Av,N Q R W,M
+R13,5 Av/59 St,N R W,M
+R11,Lexington Av/59 St,N R W 4 5 6,M
 QBP,Queensboro Plaza,7 N W,Q
 W05,36 Av,W,Q
 W04,Broadway,W,Q
 W03,30 Av,W,Q
-W02,Astoria Blvd,N W,Q
-W01,Astoria-Ditmars Blvd,N W,Q
+R03,Astoria Blvd,N W,Q
+R01,Astoria-Ditmars Blvd,N W,Q

--- a/public/csv/z_train_stations.csv
+++ b/public/csv/z_train_stations.csv
@@ -1,10 +1,10 @@
 stop_id,stop_name,transfers,borough
 M23,Broad St,J Z,M
-M22,Fulton St,2 3 4 5 A C J Z,M
+FUL,Fulton St,2 3 4 5 A C J Z,M
 M21,Chambers St,J Z,M
-M20,Canal St,6 N Q R W J Z,M
+CAN,Canal St,6 N Q R W J Z,M
 M19,Bowery,J Z,M
-M18,Delancey St-Essex St,J Z F M,M
+ESX,Delancey St-Essex St,J Z F M,M
 M16,Marcy Av,J M Z,Bk
 M11,Myrtle Av,J M Z,Bk
 J30,Gates Av,J Z,Bk

--- a/src/components/DirectionSwitch.tsx
+++ b/src/components/DirectionSwitch.tsx
@@ -55,12 +55,17 @@ export function DirectionSwitch({ state, onChange, visible }: DirectionSwitchPro
                     }`}
                     ref={labelRef}
                 >
-                    {state === Direction.UPTOWN ? 'Uptown' : state === Direction.DOWNTOWN ? 'Downtown' : 'Choose Direction'}
+                    {state === Direction.UPTOWN ? 'Uptown' : state === Direction.DOWNTOWN ? 'Downtown' : 'Choose direction'}
                 </span>
             </button>
             <div className="info-icon-container">
                 <img src={infoIcon} alt="Information" className="info-icon" />
-                <div className="tooltip">Configure the default starting direction after transferring lines</div>
+                <div className="tooltip">
+                    Configure the default starting direction{' '}
+                    <i>
+                        <u>after transferring lines</u>
+                    </i>
+                </div>
             </div>
         </div>
     )

--- a/src/components/GameStateUI.tsx
+++ b/src/components/GameStateUI.tsx
@@ -150,7 +150,7 @@ function GameStateUI() {
 
             <div className="stations-container">
                 <div className="station-box" id="current-station">
-                    <Header text="Current Station:" />
+                    <Header text="Current station" />
                     <div className="station-item">
                         <Station name={train.getCurrentStation().getName()}>
                             <TransferLines
@@ -163,12 +163,12 @@ function GameStateUI() {
                     <div className="action-buttons-container" id="starting-station">
                         <ActionButton
                             imageSrc={darkMode ? TRANSFER_WHITE : TRANSFER_BLACK}
-                            label="Transfer Lines"
+                            label="Transfer lines"
                             onClick={() => handleTrainAction('transfer')}
                         />
                         <ActionButton
                             imageSrc={darkMode ? C_DIRECTION_WHITE : C_DIRECTION_BLACK}
-                            label="Change Direction"
+                            label="Change direction"
                             onClick={() => handleTrainAction('changeDirection')}
                             additionalInput={
                                 <DirectionSwitch
@@ -182,7 +182,7 @@ function GameStateUI() {
                         />
                         <ActionButton
                             imageSrc={darkMode ? R_ARROW_WHITE : R_ARROW_BLACK}
-                            label={`Advance Station${numAdvanceStations > 1 ? 's' : ''}`}
+                            label={`Advance station${numAdvanceStations > 1 ? 's' : ''}`}
                             onClick={() => handleTrainAction('advanceStation')}
                             additionalInput={<AdvanceNStationsInput visible={conductorMode} />}
                         />
@@ -190,7 +190,7 @@ function GameStateUI() {
                 </div>
 
                 <div className="station-box" id="destination-station">
-                    <Header text="Destination Station" />
+                    <Header text="Destination station" />
                     <div className="station-item">
                         <Station name={gameState.destinationStation.getName()}>
                             <TransferLines transfers={getTransferImageSvg(gameState.destinationStation)} />
@@ -199,7 +199,7 @@ function GameStateUI() {
                     <div className="action-buttons-container" id="destination-station">
                         <ActionButton
                             imageSrc={darkMode ? REFRESH_WHITE : REFRESH_BLACK}
-                            label="Reset Game"
+                            label="Reset game"
                             onClick={() => handleTrainAction('refresh')}
                         />
                     </div>

--- a/src/components/KeyShortcutMenu.tsx
+++ b/src/components/KeyShortcutMenu.tsx
@@ -6,16 +6,16 @@ import './KeyShortcutMenu.css'
 const KeyShortcutMenu = () => {
     return (
         <>
-            <KeyShortcut shortcutKey="→" label="Advance Station" />
-            <KeyShortcut shortcutKey="t" label="Transfer Lines" />
-            <KeyShortcut shortcutKey="c" label="Change Direction" />
+            <KeyShortcut shortcutKey="→" label="Advance station" />
+            <KeyShortcut shortcutKey="t" label="Transfer lines" />
+            <KeyShortcut shortcutKey="c" label="Change direction" />
             <KeyShortcut shortcutKey="r" label="Refresh" />
-            <KeyShortcut shortcutKey="Esc" label="Exit Transfer" />
-            <KeyShortcut shortcutKey="l" label="Toggle Layout" isCommand />
-            <KeyShortcut shortcutKey="d" label="Light/Dark Mode" isCommand />
-            <KeyShortcut shortcutKey="u" label="Stations Hide/Show" isCommand />
-            <KeyShortcut shortcutKey="c" label="Conductor/Rider Mode" isCommand />
-            <KeyShortcut shortcutKey="+" label="Increase Advance Count" />
+            <KeyShortcut shortcutKey="Esc" label="Exit transfer" />
+            <KeyShortcut shortcutKey="l" label="Toggle layout" isCommand />
+            <KeyShortcut shortcutKey="d" label="Light/dark mode" isCommand />
+            <KeyShortcut shortcutKey="u" label="Stations hide/show" isCommand />
+            <KeyShortcut shortcutKey="c" label="Conductor/rider mode" isCommand />
+            <KeyShortcut shortcutKey="+" label="Increase advance count" />
             <KeyShortcut shortcutKey="-" label="Decrease Advance Count" />
         </>
     )

--- a/src/components/LineInfo.tsx
+++ b/src/components/LineInfo.tsx
@@ -13,7 +13,7 @@ function LineInfo({ direction, line, type }: LineInfoProps) {
             <div className="LineInfo-container">
                 <h2>{direction}&nbsp;&nbsp;</h2>
                 <img src={line} alt={`${line}`} className="transfer-line-image" />
-                <h2>&nbsp;&nbsp;{type} Train</h2>{' '}
+                <h2>&nbsp;&nbsp;{type} train</h2>{' '}
             </div>
         </>
     )

--- a/src/components/SettingsMenu.tsx
+++ b/src/components/SettingsMenu.tsx
@@ -32,14 +32,14 @@ const SettingsMenu = () => {
         <>
             <SettingsButton label="Theme" imgSrc={darkMode ? L_MODE : D_MODE} onClick={() => setDarkMode((prev) => !prev)} />
             <SettingsButton
-                label="Upcoming Stations"
+                label="Upcoming stations"
                 imgSrc={darkMode ? UPCOMING_STATIONS_WHITE : UPCOMING_STATIONS_BLACK}
                 onClick={() => {
                     setUpcomingStationsVisible((prev) => !prev)
                 }}
             />
             <SettingsButton
-                label="Upcoming Stations Layout"
+                label="Upcoming stations layout"
                 imgSrc={
                     upcomingStationsVertical
                         ? darkMode
@@ -56,7 +56,7 @@ const SettingsMenu = () => {
                 }}
             />
             <SettingsButton
-                label={!conductorMode ? 'Conductor Mode' : 'Rider Mode'}
+                label={!conductorMode ? 'Conductor mode' : 'Rider mode'}
                 imgSrc={
                     conductorMode
                         ? darkMode

--- a/src/components/TrainInfo.tsx
+++ b/src/components/TrainInfo.tsx
@@ -34,12 +34,12 @@ export function TrainInfo({ direction, directionLabel, currentLineSVG, lineType 
                         : {}
                 }
             >
-                {isNullDirection ? 'Toggle Direction' : directionLabel}
+                {isNullDirection ? 'TOGGLE DIRECTION' : directionLabel}
             </h2>
             <div className="train-car-line">
                 <Line transfers={[currentLineSVG]} notDim />
             </div>
-            <h2 className="train-type not-dim">{lineType + ' Train'}</h2>
+            <h2 className="train-type not-dim">{lineType + ' train'}</h2>
         </>
     )
 }

--- a/src/logic/StationManager.ts
+++ b/src/logic/StationManager.ts
@@ -28,7 +28,7 @@ export class Station {
 
     // Operators
     public equals(rhs: Station): boolean {
-        return this.name === rhs.name && this.transfersEqual(rhs.transfers)
+        return this.id === rhs.id && this.transfersEqual(rhs.transfers)
     }
 
     public notEquals(rhs: Station): boolean {
@@ -70,21 +70,6 @@ export class Station {
     // Transfers
     public getTransfers(): LineName[] {
         return this.transfers
-    }
-
-    public hasTransferLine(requestedLine?: LineName): boolean {
-        if (requestedLine) {
-            // Check if the requested line exists in transfers
-            for (const line of this.transfers) {
-                if (line === requestedLine) {
-                    return true
-                }
-            }
-            return false
-        } else {
-            // check if more than one transfer exists
-            return this.transfers.length > 1
-        }
     }
 
     public getStationByID(stationID: string) {

--- a/src/logic/TrainManager.ts
+++ b/src/logic/TrainManager.ts
@@ -186,12 +186,12 @@ export class Train {
         this.currentStationIndex = this.scheduledStops.findIndex((stop) => stop.getId() === station.getId())
     }
 
-    public setCurrentStationIndexByName(stationName: string, newScheduledStops: Station[]) {
-        this.currentStationIndex = newScheduledStops.findIndex((station) => station.getName() === stationName)
+    public setCurrentStationIndexByID(stationID: string, newScheduledStops: Station[]) {
+        this.currentStationIndex = newScheduledStops.findIndex((station) => station.getId() === stationID)
     }
 
-    public static getCurrentStationIndexByName(stationName: string, scheduledStops: Station[]): number {
-        return scheduledStops.findIndex((station) => station.getName() === stationName)
+    public static getCurrentStationIndexByID(stationID: string, scheduledStops: Station[]): number {
+        return scheduledStops.findIndex((station) => station.getId() === stationID)
     }
 
     // Transfer Logic
@@ -210,7 +210,7 @@ export class Train {
     public async transferToLine(newLine: LineName, currentStation: Station): Promise<boolean> {
         if (this.isValidTransfer(newLine, currentStation)) {
             await this.updateScheduledStops(newLine)
-            this.setCurrentStationIndexByName(currentStation.getName(), this.scheduledStops)
+            this.setCurrentStationIndexByID(currentStation.getId(), this.scheduledStops)
             this.currentLine = newLine
             this.uptownLabel = this.findDirectionLabel(Direction.UPTOWN, newLine)
             this.downtownLabel = this.findDirectionLabel(Direction.DOWNTOWN, newLine)


### PR DESCRIPTION
## Summary
When transferring lines, the game will:
1. Check `currentLine` exists at the current station's transfer array
2. Go into the requested transfer line's csv file, and reset the `currentStationIndex` accordingly

Step 2 was originally tricky, because stations that multiple lines shared had different `Ids` depending on which subway line's csv it was listed on. Because of this my code checked for station name equivalence.

### Why care?

> **my code checked for station name equivalence**

^ This is why we care. In certain special cases, station names will appear different depending on what line you are on at that station. Some examples include:

```text
                    Borough Hall (2 3 4 5) == Court St (R)
Franklin Avenue-Medgar Evers College (4 5) == Franklin Avenue/Botanic Garden (2 3 Sf)
               Bway-Lafayette St (B D F M) == Bleeker St (6)
            Whitehall St-South Ferry (R W) == South Ferry (1) ...
```


